### PR TITLE
Enable tip of tree of libparodus and fixed dependent unit tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_dependencies(libcJSON cJSON)
 ExternalProject_Add(msgpack
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/msgpack
     GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git
-    GIT_TAG "a6599e5fb4c77c829590bff3ab08859c0e20b584"
+    GIT_TAG "c6e6dbc608366090c12b142b3832604e6aa12f54"
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
                   -DMSGPACK_ENABLE_CXX=OFF
                   -DMSGPACK_BUILD_EXAMPLES=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ add_dependencies(libwrp-c wrp-c)
 ExternalProject_Add(libparodus
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/libparodus
     GIT_REPOSITORY https://github.com/Comcast/libparodus.git
-    GIT_TAG "e020ebc82ff2352c351729556671986f0f791c7e"
+    GIT_TAG "master"
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 )
 add_library(liblibparodus STATIC SHARED IMPORTED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_dependencies(libcJSON cJSON)
 ExternalProject_Add(msgpack
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/msgpack
     GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git
-    GIT_TAG "master"
+    GIT_TAG "a6599e5fb4c77c829590bff3ab08859c0e20b584"
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
                   -DMSGPACK_ENABLE_CXX=OFF
                   -DMSGPACK_BUILD_EXAMPLES=OFF

--- a/tests/libpd_test.c
+++ b/tests/libpd_test.c
@@ -70,8 +70,6 @@ extern const char *client_url;
 extern volatile int keep_alive_count;
 extern volatile int reconnect_count;
 
-parlibLogHandler test_log_handler = NULL;
-
 void show_src_dest_payload (char *src, char *dest, void *payload, size_t payload_size)
 {
 	size_t i;
@@ -272,8 +270,7 @@ void test_send_only (void)
 	unsigned event_num = 0;
 
         libpd_cfg_t cfg = {.service_name = service_name,
-                .receive = false, .keepalive_timeout_secs = 0,
-                .log_handler = test_log_handler};
+                .receive = false, .keepalive_timeout_secs = 0};
         CU_ASSERT (libparodus_init (&test_instance, &cfg) == 0);
         CU_ASSERT (send_event_msgs (NULL, &event_num, 10) == 0);
 	CU_ASSERT (libparodus_shutdown (&test_instance) == 0);
@@ -287,10 +284,7 @@ void test_send_only (void)
 	unsigned event_num = 0;
 	unsigned msg_num = 0;
         libpd_cfg_t cfg = {.service_name = service_name,
-                .receive = true, .keepalive_timeout_secs = 0,
-                .log_handler = test_log_handler};
-
-	CU_ASSERT_FATAL (log_init (".", NULL) == 0);
+                .receive = true, .keepalive_timeout_secs = 0};
 
 	if (no_mock_send_only_test) {
 		test_send_only ();
@@ -338,7 +332,7 @@ static void initEndKeypressHandler()
 	err = pthread_create(&endKeypressThreadId, NULL, endKeypressHandlerTask, NULL);
 	if (err != 0) 
 	{
-		libpd_log (LEVEL_ERROR, err, "Error creating End Keypress Handler thread\n");
+		libpd_log (LEVEL_ERROR, "Error creating End Keypress Handler thread\n");
 	}
 	else 
 	{


### PR DESCRIPTION
1. Enable tip of tree of libparodus and fixed dependent unit tests.
2. Fixed Travis build by using msgpack 2.1.1 that does not fail.