### PR TITLE
Added matchFlag reset to fix iot start up issue on yocto

### DIFF
--- a/src/upstream.c
+++ b/src/upstream.c
@@ -204,6 +204,8 @@ void *processUpstreamMessage()
                     //Extract serviceName and url & store it in a linked list for reg_clients
                     if(get_numOfClients() !=0)
                     {
+			matchFlag = 0;
+			ParodusPrint("matchFlag reset to %d\n", matchFlag);
                         temp = get_global_node();
                         while(temp!=NULL)
                         {


### PR DESCRIPTION
If same client service is trying to register again, matchFlag will be set to 1. Before any other services are trying to register with parodus, reset for this matchFlag should be done and will get added to registered list.