### PR TITLE
Generic solution for linking lib dir install path based on linux architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,7 @@ include(CTest)
 set(INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/_install)
 set(PREFIX_DIR ${CMAKE_CURRENT_BINARY_DIR}/_prefix)
 set(INCLUDE_DIR ${INSTALL_DIR}/include)
-set(LIBRARY_DIR ${INSTALL_DIR}/lib)
-set(NANOMSG_LIBRARY_DIR ${INSTALL_DIR}/lib/x86_64-linux-gnu)
-set(LIBRARY_DIR64 ${INSTALL_DIR}/lib64)
+set(LIBRARY_DIR ${INSTALL_DIR}/lib ${INSTALL_DIR}/lib/${CMAKE_LIBRARY_ARCHITECTURE})
 set(TEST_RESULTS_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_results)
 file(MAKE_DIRECTORY ${TEST_RESULTS_DIR})
 
@@ -193,7 +191,7 @@ endif (BUILD_TESTING)
 
 endif ()
 
-link_directories ( ${LIBRARY_DIR} ${LIBRARY_DIR64} ${NANOMSG_LIBRARY_DIR} )
+link_directories ( ${LIBRARY_DIR})
 
 add_subdirectory(src)
 if (BUILD_TESTING)


### PR DESCRIPTION
CMAKE_LIBRARY_ARCHITECTURE is used to represent the x86* or i386* lib folder in different linux architecture