### PR TITLE
To fix travis build failure due to log flooding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ add_dependencies(libcimplog cimplog)
 # wrp-c external dependency
 #-------------------------------------------------------------------------------
 ExternalProject_Add(wrp-c
+	DEPENDS trower-base64 msgpack cimplog
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/wrp-c
     GIT_REPOSITORY https://github.com/Comcast/wrp-c.git
     GIT_TAG "master"
@@ -152,6 +153,9 @@ ExternalProject_Add(wrp-c
                   -DMSGPACK_ENABLE_CXX=OFF
                   -DMSGPACK_BUILD_EXAMPLES=OFF
                   -DBUILD_TESTING=OFF
+                  -DMAIN_PROJ_BUILD=ON
+                  -DMAIN_PROJ_LIB_PATH=${LIBRARY_DIR}
+    		  -DMAIN_PROJ_INCLUDE_PATH=${INCLUDE_DIR}
 )
 add_library(libwrp-c STATIC SHARED IMPORTED)
 add_dependencies(libwrp-c wrp-c)
@@ -159,10 +163,14 @@ add_dependencies(libwrp-c wrp-c)
 # libparodus external dependency
 #-------------------------------------------------------------------------------
 ExternalProject_Add(libparodus
+    DEPENDS trower-base64 msgpack nanomsg wrp-c
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/libparodus
     GIT_REPOSITORY https://github.com/Comcast/libparodus.git
     GIT_TAG "master"
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+    		  -DMAIN_PROJ_BUILD=ON
+    		  -DMAIN_PROJ_LIB_PATH=${LIBRARY_DIR}
+    		  -DMAIN_PROJ_INCLUDE_PATH=${INCLUDE_DIR}
 )
 add_library(liblibparodus STATIC SHARED IMPORTED)
 add_dependencies(liblibparodus libparodus)
@@ -170,9 +178,13 @@ add_dependencies(liblibparodus libparodus)
 # libseshat external dependency
 #-------------------------------------------------------------------------------
 ExternalProject_Add(libseshat
+    DEPENDS cJSON trower-base64 msgpack wrp-c
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/libseshat
     GIT_REPOSITORY https://github.com/comcast/seshat.git
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+    	          -DMAIN_PROJ_BUILD=ON
+    	          -DMAIN_PROJ_LIB_PATH=${LIBRARY_DIR}
+    		  -DMAIN_PROJ_INCLUDE_PATH=${INCLUDE_DIR}
 )
 add_library(liblibseshat STATIC SHARED IMPORTED)
 add_dependencies(liblibseshat libseshat)


### PR DESCRIPTION
In parodus, while building sub projects using ExternalProject Add, now new arguments are passed.

-DPARODUS_BUILD=ON   (to indicate parodus main project is building)

-DPARODUS_LIB_PATH=${LIBRARY_DIR} (to use parodus main _install/lib path in external sub projects like wrp-c, libparodus and seshat)

-DPARODUS_INCLUDE_PATH=${INCLUDE_DIR} (to use parodus main _install/include path in external sub projects)

If PARODUS_BUILD flag is ON , in sub projects disabled external project builds (which was causing log flooding in travis). Also link_directories() and include_directories() are updated to use the parodus main lib and include directories instead of using its own install paths.

With this, travis build is success and observed log file size is reduced to 895 KB from 4.5 MB. Also travis build time is reduced to 10 minutes which was earlier 18 min.
