### PR TITLE
Added parodus version along with git commit hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,18 @@ include_directories(${INCLUDE_DIR}
                     ${INCLUDE_DIR}/cimplog
                     ${INCLUDE_DIR}/libseshat
                     ${INCLUDE_DIR}/cjwt
-					)		
+					)	
+
+# Get git commit hash 
+#-------------------------------------------------------------------------------
+execute_process(
+  COMMAND git describe --tags --always
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_TAG
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+add_definitions("-DGIT_COMMIT_TAG=\"${GIT_COMMIT_TAG}\"")	
 
 # Compile options/flags
 #-------------------------------------------------------------------------------

--- a/src/config.c
+++ b/src/config.c
@@ -437,7 +437,8 @@ void loadParodusCfg(ParodusCfg * config,ParodusCfg *cfg)
     cfg->webpa_ping_timeout = pConfig->webpa_ping_timeout;
     cfg->webpa_backoff_max = pConfig->webpa_backoff_max;
     strncpy(cfg->webpa_path_url, WEBPA_PATH_URL, strlen(WEBPA_PATH_URL)+1);
-    strncpy(cfg->webpa_protocol, WEBPA_PROTOCOL_VALUE, strlen(WEBPA_PROTOCOL_VALUE)+1);
+    snprintf(cfg->webpa_protocol, sizeof(cfg->webpa_protocol), "%s-%s", PROTOCOL_VALUE, GIT_COMMIT_TAG);
+	ParodusPrint("cfg->webpa_protocol is %s\n", cfg->webpa_protocol);
     strncpy(cfg->webpa_uuid, "1234567-345456546", strlen("1234567-345456546")+1);
     ParodusPrint("cfg->webpa_uuid is :%s\n", cfg->webpa_uuid);
     

--- a/src/config.h
+++ b/src/config.h
@@ -34,7 +34,7 @@ extern "C" {
 #define WEBPA_BACKOFF_MAX                               "webpa-backoff-max"
 #define PARTNER_ID                                      "partner-id"
 
-#define WEBPA_PROTOCOL_VALUE 				"WebPA-1.6"
+#define PROTOCOL_VALUE 					"PARODUS-2.0"
 #define WEBPA_PATH_URL                                    "/api/v2/device"
 #define JWT_ALGORITHM					"jwt-algo"
 #define	JWT_KEY						"jwt-key"
@@ -59,7 +59,7 @@ typedef struct
     char webpa_path_url[124];
     unsigned int webpa_backoff_max;
     char webpa_interface_used[16];
-    char webpa_protocol[16];
+    char webpa_protocol[32];
     char webpa_uuid[64];
     unsigned int secureFlag;
     char dns_id[64];

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -245,7 +245,6 @@ void test_loadParodusCfgNull()
     assert_string_equal(temp.hw_manufacturer, "");
     assert_int_equal( (int) temp.secureFlag,1);	
     assert_string_equal( temp.webpa_path_url, WEBPA_PATH_URL);	
-    assert_string_equal( temp.webpa_protocol, WEBPA_PROTOCOL_VALUE);
     assert_string_equal( temp.webpa_uuid,"1234567-345456546");
     assert_string_equal( temp.local_url, PARODUS_UPSTREAM);
 


### PR DESCRIPTION
Changes are added in CMakeLists.txt to fetch latest git hash version and will be updated to "GIT_COMMIT_TAG" variable. To access this value in C code, add_definitions is used in CMakeLists.txt.

Please confirm webpa_protocol format which we need to support. Currently it is added as "PARODUS 2.0 0da33e5".

Sample log:
X-WebPA-Convey Header: [315]{"hw-model":"TG1682G","hw-serial-number":"E8GBUE575601511","hw-manufacturer":"ARRIS","fw-name":"TG1682_DEV_master_20170707114404sdy","boot-time":1499428258,"webpa-protocol":"PARODUS 2.0 0da33e5","webpa-inteface-used":"erouter0","hw-last-reboot-reason":"unknown","webpa-last-reconnect-reason":"webpa_process_starts"}