### PR TITLE
spin_thread.c: don't assume pthread_t can be cast to int

### DIFF
--- a/src/spin_thread.c
+++ b/src/spin_thread.c
@@ -44,7 +44,7 @@ void StartThread(void *(*start_routine) (void *))
 	}
 	else
 	{
-		ParodusPrint("Thread created Successfully %d\n", (int ) threadId);
+		ParodusPrint("Thread created Successfully %lu\n", (unsigned long) threadId);
 	}    
 }
 


### PR DESCRIPTION
Fix build issues for 64bit targets.
