### PR TITLE
fix test_errParseCommandLine in test_config.c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
     - cd build
     - cmake .. -DINTEGRATION_TESTING:BOOL=false -DDISABLE_VALGRIND:BOOL=true -DENABLE_SESHAT:BOOL=true -DFEATURE_DNS_QUERY:BOOL=true
     - make
+    - export ARGS="-V"
     - make test
 
 after_success:

--- a/src/config.c
+++ b/src/config.c
@@ -230,7 +230,7 @@ int parse_webpa_url(const char *full_url,
 
 }
 
-void parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
+int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 {
     static const struct option long_options[] = {
         {"hw-model",                required_argument, 0, 'm'},
@@ -265,7 +265,7 @@ void parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 
 	if (NULL == cfg) {
 		ParodusError ("NULL cfg structure\n");
-		return;
+		return -1;
 	} 
 	cfg->flags = 0;
     while (1)
@@ -417,7 +417,7 @@ void parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 
         default:
            ParodusError("Enter Valid commands..\n");
-          abort ();
+		   return -1;
         }
     }
 
@@ -432,6 +432,7 @@ void parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
         ParodusPrint ("%s ", argv[optind++]);
       putchar ('\n');
     }
+    return 0;
 }
 
 /*

--- a/src/config.h
+++ b/src/config.h
@@ -102,7 +102,18 @@ typedef struct
 
 void loadParodusCfg(ParodusCfg * config,ParodusCfg *cfg);
 void createNewAuthToken(char *newToken, size_t len);
-void parseCommandLine(int argc,char **argv,ParodusCfg * cfg);
+
+/**
+ * parse command line arguments and create config structure
+ * and return whether args are valid or not
+ *
+ * @param argc	number of command line arguments
+ * @param argv	command line argument lis
+ * @return 0 if OK
+*    or -1 if error
+*/ 
+int parseCommandLine(int argc,char **argv,ParodusCfg * cfg);
+
 void setDefaultValuesToCfg(ParodusCfg *cfg); 
 void getAuthToken(ParodusCfg *cfg);
 // Accessor for the global config structure.

--- a/src/main.c
+++ b/src/main.c
@@ -77,7 +77,9 @@ int main( int argc, char **argv)
     
     ParodusInfo("********** Starting component: Parodus **********\n "); 
     setDefaultValuesToCfg(cfg);
-    parseCommandLine(argc,argv,cfg);
+    if (0 != parseCommandLine(argc,argv,cfg)) {
+		abort();
+	}
     getAuthToken(cfg);
      
     createSocketConnection( NULL);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -157,7 +157,7 @@ void test_parseCommandLine()
     ParodusCfg parodusCfg;
     memset(&parodusCfg,0,sizeof(parodusCfg));
     create_token_script("/tmp/token.sh");
-    parseCommandLine(argc,command,&parodusCfg);
+    assert_int_equal (parseCommandLine(argc,command,&parodusCfg), 0);
 
     assert_string_equal( parodusCfg.hw_model, "TG1682");
     assert_string_equal( parodusCfg.hw_serial_number, "Fer23u948590");
@@ -193,24 +193,23 @@ void test_parseCommandLine()
 
 void test_parseCommandLineNull()
 {
-    parseCommandLine(0,NULL,NULL);
+    assert_int_equal (parseCommandLine(0,NULL,NULL), -1);
 }
 
 void err_parseCommandLine()
 {
-	int argc = 19;
+	int argc = 3;
     char * command[20]={'\0'};
 
     command[0] = "parodus";
     command[1] = "--hw-model=TG1682";
-    command[12] = "webpa";
+    command[2] = "--nosuch=0";
+    command[3] = NULL;
 
     ParodusCfg parodusCfg;
     memset(&parodusCfg,0,sizeof(parodusCfg));
 
-    parseCommandLine(argc,command,&parodusCfg);
-    assert_string_equal( parodusCfg.hw_model, "");
-    assert_string_equal( parodusCfg.hw_serial_number, "");
+    assert_int_equal (parseCommandLine(argc,command,&parodusCfg), -1);
 }
 
 void test_loadParodusCfg()
@@ -358,7 +357,7 @@ int main(void)
         cmocka_unit_test(err_loadParodusCfg),
         cmocka_unit_test(test_parseCommandLine),
         cmocka_unit_test(test_parseCommandLineNull),
-        //cmocka_unit_test(err_parseCommandLine),
+        cmocka_unit_test(err_parseCommandLine),
         cmocka_unit_test(test_parodusGitVersion),
         cmocka_unit_test(test_setDefaultValuesToCfg),
         cmocka_unit_test(err_setDefaultValuesToCfg),

--- a/tests/test_seshat_interface.c
+++ b/tests/test_seshat_interface.c
@@ -50,21 +50,6 @@ ParodusCfg *get_parodus_cfg(void)
     return &g_config;
 }
 
-void loadParodusCfg(ParodusCfg *config, ParodusCfg *cfg)
-{
-    UNUSED(config); UNUSED(cfg);
-}
-
-void parseCommandLine(int argc,char **argv, ParodusCfg *cfg)
-{
-    UNUSED(argc); UNUSED(argv); UNUSED(cfg);
-}
-
-void set_parodus_cfg(ParodusCfg *cfg)
-{
-    UNUSED(cfg);
-}
-
 int init_lib_seshat (const char *url)
 {
     UNUSED(url);


### PR DESCRIPTION
In order to make this more testable, changed parseCommandLine to return an error (-1)
rather than abort.  The caller (in main.c)  can abort if there's an error.