### PR TITLE
Changed dns query retry logic

### DIFF
--- a/src/token.c
+++ b/src/token.c
@@ -482,9 +482,6 @@ int allow_insecure_conn(char *url_buf, int url_buflen,
 	char *jwt_token, *key;
 	cjwt_t *jwt = NULL;
 	char dns_txt_record_id[TXT_REC_ID_MAXSIZE];
-	int backoffRetryTime = 0;  
-	int c=2;
-	int retry_count = 0;
 	
 	jwt_token = malloc (NS_MAXBUF);
 	if (NULL == jwt_token) {
@@ -495,32 +492,11 @@ int allow_insecure_conn(char *url_buf, int url_buflen,
 
 	get_dns_txt_record_id (dns_txt_record_id);
 	
-	/* Backoff retry when query_dns failure (pattern 3,7,15,31,63 .) */
-	
-	while(retry_count<=5)
-	{
-		backoffRetryTime = (int) pow(2, c) -1;
+	ret = query_dns(dns_txt_record_id, jwt_token);
+	ParodusPrint("query_dns returns %d\n", ret);
 		
-		ret = query_dns(dns_txt_record_id, jwt_token);
-		ParodusPrint("query_dns returns %d\n", ret);
-		
-		if(ret == 0)
-		{
-			retry_count = 0;
-			ParodusInfo("query_dns is success ..\n");
-			break;
-		}
-		else
-		{ 
-			ParodusInfo("query_dns backoffRetryTime %d seconds\n", backoffRetryTime);
-			sleep(backoffRetryTime);
-                        c++;
-			retry_count++;
-		}
-	}
-	
 	if(ret){
-		ParodusError("query_dns: failure ..\n");
+		ParodusError("Failed in DNS query\n");
 		if (ret == TOKEN_ERR_MEMORY_FAIL){
 			insecure = ret;
 		} 

--- a/tests/test_createConnection.c
+++ b/tests/test_createConnection.c
@@ -27,6 +27,7 @@
 #include "../src/ParodusInternal.h"
 #include "../src/connection.h"
 #include "../src/config.h"
+#include "../src/token.h"
 
 #define SECURE_WEBPA_URL	"https://127.0.0.1"
 #define UNSECURE_WEBPA_URL	"http://127.0.0.1"
@@ -239,15 +240,14 @@ void test_createSecureConnection()
 
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 0);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
-
     expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
     
 #ifdef FEATURE_DNS_QUERY
@@ -309,15 +309,14 @@ void test_createConnection()
     set_parodus_cfg(cfg);
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 1);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
-
 
     expect_value(nopoll_conn_new_opts, (intptr_t)ctx, (intptr_t)ctx);
     
@@ -367,14 +366,14 @@ void test_createConnectionConnNull()
     
     assert_non_null(ctx);
 
-#ifdef FEATURE_DNS_QUERY
-        setGlobalJWTUrl ("127.0.0.2");
-	will_return (allow_insecure_conn, 0);
-	expect_function_call (allow_insecure_conn);
-#endif
-
     will_return(getWebpaConveyHeader, (intptr_t)"");
     expect_function_call(getWebpaConveyHeader);
+
+#ifdef FEATURE_DNS_QUERY
+        setGlobalJWTUrl ("127.0.0.2");
+	will_return (allow_insecure_conn, -2);
+	expect_function_call (allow_insecure_conn);
+#endif
 
     expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 
@@ -399,7 +398,7 @@ void test_createConnectionConnNull()
 #else
     expect_string(nopoll_conn_tls_new, (intptr_t)host_ip, HOST_IP);
 #endif    
-    
+
     will_return(nopoll_conn_tls_new, (intptr_t)NULL);
     expect_function_call(nopoll_conn_tls_new);
 
@@ -407,6 +406,12 @@ void test_createConnectionConnNull()
     expect_function_call(checkHostIp);
 
     expect_function_call(getCurrentTime);
+
+#ifdef FEATURE_DNS_QUERY
+        setGlobalJWTUrl ("127.0.0.2");
+	will_return (allow_insecure_conn, TOKEN_ERR_QUERY_DNS_FAIL);
+	expect_function_call (allow_insecure_conn);
+#endif
 
 	expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY
@@ -447,6 +452,12 @@ void test_createConnectionConnNull()
 
     will_return(kill, 1);
     expect_function_call(kill);
+
+#ifdef FEATURE_DNS_QUERY
+        setGlobalJWTUrl ("127.0.0.2");
+	will_return (allow_insecure_conn, 0);
+	expect_function_call (allow_insecure_conn);
+#endif
 
     expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
     
@@ -509,14 +520,14 @@ void test_createConnNull_JWT_NULL()
     
     assert_non_null(ctx);
 
-#ifdef FEATURE_DNS_QUERY
-        setGlobalJWTUrl ("");
-	will_return (allow_insecure_conn, 0);
-	expect_function_call (allow_insecure_conn);
-#endif
-
     will_return(getWebpaConveyHeader, (intptr_t)"");
     expect_function_call(getWebpaConveyHeader);
+
+#ifdef FEATURE_DNS_QUERY
+        setGlobalJWTUrl ("");
+	will_return (allow_insecure_conn, TOKEN_ERR_MEMORY_FAIL);
+	expect_function_call (allow_insecure_conn);
+#endif
 
     expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 
@@ -647,14 +658,14 @@ void test_createConnectionConnNotOk()
     set_parodus_cfg(cfg);
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 1);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
     expect_value(nopoll_conn_new_opts, (intptr_t)ctx, (intptr_t)ctx);
 
@@ -744,14 +755,14 @@ void test_createConnNotOk_JWT_NULL()
     set_parodus_cfg(cfg);
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("");
 	will_return (allow_insecure_conn, 1);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
     expect_value(nopoll_conn_new_opts, (intptr_t)ctx, (intptr_t)ctx);
 
@@ -841,14 +852,14 @@ void test_createConnectionConnRedirect()
     set_parodus_cfg(cfg);
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
         setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 1);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
     expect_value(nopoll_conn_new_opts, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY
@@ -935,14 +946,14 @@ void test_createIPv4Connection()
 
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 0);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
 	expect_value(nopoll_conn_tls_new, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY
@@ -984,14 +995,14 @@ void test_createIPv6Connection()
 
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 0);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
 	expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY
@@ -1035,14 +1046,14 @@ void test_createIPv6toIPv4Connection()
 
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 0);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
 	expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY
@@ -1111,14 +1122,14 @@ void test_createFallbackRedirectionConn()
 
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 0);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
 	expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY
@@ -1212,14 +1223,14 @@ void test_createIPv6FallbackRedirectConn()
 
     assert_non_null(ctx);
 
+    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
+    expect_function_call(getWebpaConveyHeader);
+
 #ifdef FEATURE_DNS_QUERY
 	setGlobalJWTUrl ("127.0.0.2");
 	will_return (allow_insecure_conn, 0);
 	expect_function_call (allow_insecure_conn);
 #endif
-
-    will_return(getWebpaConveyHeader, (intptr_t)"WebPA-1.6 (TG1682)");
-    expect_function_call(getWebpaConveyHeader);
 
 	expect_value(nopoll_conn_tls_new6, (intptr_t)ctx, (intptr_t)ctx);
 #ifdef FEATURE_DNS_QUERY


### PR DESCRIPTION
parodus connection is delayed on some of the devices due to backoff retry on dns failure and connection failure. So removed backoff retry on dns_query failure and using existing backoff retry of connection failure to avoid multiple retries. 

Implementation notes are:
- Removed existing backoff retry on dns query failure
- Moved jwt validation code inside connection do-while loop such that it will retry on every connection failure
- Added condition to validate jwt on initial connection and on query dns failure
- Modified existing test cases to match this new logic