### PR TITLE
Reset jwt status when acquire_jwt is 0

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -179,6 +179,13 @@ int createNopollConnection(noPollCtx *ctx)
                 if (jwt_status >= 0)
                     allow_insecure = jwt_status;
             }
+            else
+            {
+                ParodusInfo("JWT validation is disabled\n");
+                jwt_status = 1;
+            }
+#else
+            jwt_status = 1;
 #endif
             ParodusInfo("server_Address %s\n",server_Address);
             ParodusInfo("port %s\n", port);


### PR DESCRIPTION
parodus connection is keep on retrying when acquire_jwt is 0 or FEATURE_DNS_QUERY is OFF with recent change in dns query logic. Reset of jwt_status is missed in these 2 cases. So added reset to fix retry issue.