### PR TITLE
Use length code when parsing rr recs in token.c

### DIFF
--- a/src/token.c
+++ b/src/token.c
@@ -233,11 +233,10 @@ static bool is_digit (char c)
 // strip quotes and newlines from rr rec
 const char *strip_rr_data (const char *rr_ptr, int *rrlen)
 {
-	int len;
+	int len = *rrlen;
 	const char *optr = rr_ptr;
 	char c;
 
-	len = strlen (optr);
 	if (len > 0) {
 		c = optr[0];
 		if (!is_digit(c)) {
@@ -338,6 +337,7 @@ int get_rr_seq_table (ns_msg *msg_handle, int num_rr_recs, rr_rec_t *seq_table)
     	continue;
 		++num_txt_recs;
     rr_ptr = (const char *)ns_rr_rdata(rr);
+    rrlen = ns_rr_rdlen(rr);
 		ParodusPrint ("Found rr rec type %d: %s\n", ns_t_txt, rr_ptr);
 		rr_ptr = strip_rr_data (rr_ptr, &rrlen);		
 		seq_pos = find_seq_num (rr_ptr, rrlen);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -214,7 +214,13 @@ target_link_libraries (test_thread_tasks -lcmocka ${PARODUS_COMMON_LIBS} )
 #   test_conn_interface
 #-------------------------------------------------------------------------------
 add_test(NAME test_conn_interface COMMAND ${MEMORY_CHECK} ./test_conn_interface)
-set(CONIFC_SRC test_conn_interface.c ../src/conn_interface.c ../src/config.c ../src/string_helpers.c ../src/mutex.c)
+set(CONIFC_SRC test_conn_interface.c 
+  ../src/conn_interface.c 
+  ../src/config.c 
+  ../src/token.c
+  ../src/string_helpers.c 
+  ../src/mutex.c
+)
 if (ENABLE_SESHAT)
 set(CONIFC_SRC ${CONIFC_SRC} ../src/seshat_interface.c)
 else()

--- a/tests/test_token.c
+++ b/tests/test_token.c
@@ -225,6 +225,9 @@ static int get_dns_text (const char *dns_rec_id, u_char *nsbuf, int bufsize)
 /*                                   Mocks                                    */
 /*----------------------------------------------------------------------------*/
 
+// These mocks assume that the pieces of a dns txt record end with '\n';
+
+
 int ns_initparse(const u_char *nsbuf, int l, ns_msg *msg_handle)
 {
 	UNUSED(l);
@@ -269,12 +272,14 @@ int ns_parserr(ns_msg *msg_handle, ns_sect sect, int rec, ns_rr *rr)
 		ptr += (l+1);
 	}
 
-	if (strlen (ptr) == 0) {
+	l = strlen(ptr);
+	if (l == 0) {
 		rr->type = ns_t_key;
 	} else {
 		rr->type = ns_t_txt;
 	}
 	rr->rdata = (u_char *) ptr;
+	rr->rdlength = l; 
 	return 0;
 }
 
@@ -382,12 +387,14 @@ void test_strip_rrdata ()
 	const char *result;
   int rlen;
 
+	rlen = strlen (s1);
 	result = strip_rr_data (s1, &rlen);
 	assert_int_equal (rlen, s1len);
 	if (rlen == s1len) {
 		assert_int_equal (strncmp (result, ss1, rlen), 0);
 	}
 
+	rlen = strlen (s2);
 	result = strip_rr_data (s2, &rlen);
 	assert_int_equal (rlen, s1len);
 	if (rlen == s1len) {


### PR DESCRIPTION
To fix CJWT decode error.
Should be using length code instead of strlen.
