### PR TITLE
fixes Comcast/parodus#194 parse_webpa_url function doesn't correctly return server address

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -230,6 +230,12 @@ int parse_webpa_url(const char *full_url,
 			parStrncpy (port_buf, "80", port_buflen);
 		else
 			parStrncpy (port_buf, "443", port_buflen);
+
+		end_port = strchr (server_addr, '/');
+		if (NULL != end_port) {
+			*end_port = '\0'; // terminate server address with null
+		}
+
 	} else {
 		*port_val = '\0'; // terminate server address with null
 		port_val++;

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -463,6 +463,10 @@ void test_parse_webpa_url ()
 		addr_buf, 80, port_buf, 8), 0);
 	assert_string_equal (addr_buf, "mydns.mycom.net");
 	assert_string_equal (port_buf, "443");
+	assert_int_equal (parse_webpa_url ("https://mydns.mycom.net/api/v2/",
+		addr_buf, 80, port_buf, 8), 0);
+	assert_string_equal (addr_buf, "mydns.mycom.net");
+	assert_string_equal (port_buf, "443");
 	assert_int_equal (parse_webpa_url ("http://mydns.mycom.net:8080",
 		addr_buf, 80, port_buf, 8), 1);
 	assert_string_equal (addr_buf, "mydns.mycom.net");


### PR DESCRIPTION
If the redirect from Petasos returns a URL which has an URI with "/api/v2/" the
parse_webpa_url function must only return in address_buffer the server
and not the server/api/v2/ as shown in the test case