### PR TITLE
Reset connection error trigger

### DIFF
--- a/src/nopoll_helpers.c
+++ b/src/nopoll_helpers.c
@@ -55,9 +55,14 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
 {
     int bytesWritten = 0;
     static int connErr=0;
+    nopoll_bool conn_ok;
+    nopoll_bool conn_ready;
 
     ParodusInfo("sendMessage length %zu\n", len);
-    if(nopoll_conn_is_ok(conn) && nopoll_conn_is_ready(conn))
+    conn_ok    = nopoll_conn_is_ok(conn);
+    conn_ready = nopoll_conn_is_ready(conn);
+
+    if(conn_ok && conn_ready)
     {
         //bytesWritten = nopoll_conn_send_binary(conn, msg, len);
         bytesWritten = sendResponse(conn, msg, len);
@@ -66,10 +71,12 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
         {
             ParodusError("Failed to send bytes %zu, bytes written were=%d (errno=%d, %s)..\n", len, bytesWritten, errno, strerror(errno));
         }
+	connErr = 0;
     }
     else
     {
-        ParodusError("Failed to send msg upstream as connection is not OK\n");
+        ParodusError("Failed to send msg upstream! Connection OK %s, READY %s\n", conn_ok ? "true" : "false",
+		      conn_ready ? "true" : "false");
 		if (connErr == 0)
 		{
 			getCurrentTime(connStuck_startPtr);

--- a/src/nopoll_helpers.c
+++ b/src/nopoll_helpers.c
@@ -55,14 +55,10 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
 {
     int bytesWritten = 0;
     static int connErr=0;
-    nopoll_bool conn_ok;
-    nopoll_bool conn_ready;
 
     ParodusInfo("sendMessage length %zu\n", len);
-    conn_ok    = nopoll_conn_is_ok(conn);
-    conn_ready = nopoll_conn_is_ready(conn);
 
-    if(conn_ok && conn_ready)
+    if(nopoll_conn_is_ok(conn) && nopoll_conn_is_ready(conn))
     {
         //bytesWritten = nopoll_conn_send_binary(conn, msg, len);
         bytesWritten = sendResponse(conn, msg, len);
@@ -75,8 +71,7 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
     }
     else
     {
-                ParodusError("Failed to send msg upstream! Connection OK (%s) READY(%s)\n",
-			      conn_ok ? "true" : "false", conn_ready ? "true" : "false");
+                ParodusError("Failed to send msg upstream as connection is not OK\n");
 		if (connErr == 0)
 		{
 			getCurrentTime(connStuck_startPtr);

--- a/src/nopoll_helpers.c
+++ b/src/nopoll_helpers.c
@@ -55,14 +55,14 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
 {
     int bytesWritten = 0;
     static int connErr=0;
-    nopoll_bool conn_ok;
-    nopoll_bool conn_ready;
+    //nopoll_bool conn_ok;
+    //nopoll_bool conn_ready;
 
     ParodusInfo("sendMessage length %zu\n", len);
-    conn_ok    = nopoll_conn_is_ok(conn);
-    conn_ready = nopoll_conn_is_ready(conn);
+    //conn_ok    = nopoll_conn_is_ok(conn);
+    //conn_ready = nopoll_conn_is_ready(conn);
 
-    if(conn_ok && conn_ready)
+    if(nopoll_conn_is_ok(conn) && nopoll_conn_is_ready(conn))
     {
         //bytesWritten = nopoll_conn_send_binary(conn, msg, len);
         bytesWritten = sendResponse(conn, msg, len);
@@ -75,8 +75,7 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
     }
     else
     {
-        ParodusError("Failed to send msg upstream! Connection OK %s, READY %s\n", conn_ok ? "true" : "false",
-		      conn_ready ? "true" : "false");
+                ParodusError("Failed to send msg upstream! Connection not OK or not READY\n");
 		if (connErr == 0)
 		{
 			getCurrentTime(connStuck_startPtr);

--- a/src/nopoll_helpers.c
+++ b/src/nopoll_helpers.c
@@ -55,14 +55,14 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
 {
     int bytesWritten = 0;
     static int connErr=0;
-    //nopoll_bool conn_ok;
-    //nopoll_bool conn_ready;
+    nopoll_bool conn_ok;
+    nopoll_bool conn_ready;
 
     ParodusInfo("sendMessage length %zu\n", len);
-    //conn_ok    = nopoll_conn_is_ok(conn);
-    //conn_ready = nopoll_conn_is_ready(conn);
+    conn_ok    = nopoll_conn_is_ok(conn);
+    conn_ready = nopoll_conn_is_ready(conn);
 
-    if(nopoll_conn_is_ok(conn) && nopoll_conn_is_ready(conn))
+    if(conn_ok && conn_ready)
     {
         //bytesWritten = nopoll_conn_send_binary(conn, msg, len);
         bytesWritten = sendResponse(conn, msg, len);
@@ -75,7 +75,8 @@ void sendMessage(noPollConn *conn, void *msg, size_t len)
     }
     else
     {
-                ParodusError("Failed to send msg upstream! Connection not OK or not READY\n");
+                ParodusError("Failed to send msg upstream! Connection OK (%s) READY(%s)\n",
+			      conn_ok ? "true" : "false", conn_ready ? "true" : "false");
 		if (connErr == 0)
 		{
 			getCurrentTime(connStuck_startPtr);

--- a/tests/test_nopoll_helpers.c
+++ b/tests/test_nopoll_helpers.c
@@ -234,10 +234,6 @@ void err_sendMessageConnNull()
     expect_value(nopoll_conn_is_ok, (intptr_t)conn, (intptr_t)NULL);
     will_return(nopoll_conn_is_ok, nopoll_false);
     expect_function_call(nopoll_conn_is_ok);
- 
-    expect_value(nopoll_conn_is_ready, (intptr_t)conn, (intptr_t)NULL);
-    will_return(nopoll_conn_is_ready, nopoll_false);
-    expect_function_call(nopoll_conn_is_ready);    
 
     sendMessage(NULL, "Hello Parodus!", len);
 }

--- a/tests/test_nopoll_helpers.c
+++ b/tests/test_nopoll_helpers.c
@@ -234,7 +234,11 @@ void err_sendMessageConnNull()
     expect_value(nopoll_conn_is_ok, (intptr_t)conn, (intptr_t)NULL);
     will_return(nopoll_conn_is_ok, nopoll_false);
     expect_function_call(nopoll_conn_is_ok);
-    
+ 
+    expect_value(nopoll_conn_is_ready, (intptr_t)conn, (intptr_t)NULL);
+    will_return(nopoll_conn_is_ready, nopoll_false);
+    expect_function_call(nopoll_conn_is_ready);    
+
     sendMessage(NULL, "Hello Parodus!", len);
 }
 


### PR DESCRIPTION
The logic here seems incorrect, there seems to be intermittent failures (possibly redirect messages cause it?) that sets a trigger to kill the process in 10 minutes; however the trigger is never reset if the error goes away. 