### PR TITLE
Fixes crash in parodus WEBPA-2468

### DIFF
--- a/src/upstream.c
+++ b/src/upstream.c
@@ -78,7 +78,7 @@ pthread_mutex_t *get_global_nano_mut(void)
 
 void packMetaData()
 {
-    char boot_time[256]={'\0'};
+    static char boot_time[256]={'\0'};
     //Pack the metadata initially to reuse for every upstream msg sending to server
     ParodusPrint("-------------- Packing metadata ----------------\n");
     sprintf(boot_time, "%d", get_parodus_cfg()->boot_time);

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -336,7 +336,7 @@ void *processUpstreamMessage()
             }
 
 			//nn_freemsg should not be done for parodus/tags/ CRUD requests as it is not received through nanomsg.
-			if ((msg->u.crud.source !=NULL) && strstr(msg->u.crud.source, "parodus") != NULL)
+			if ((msg && (msg->u.crud.source !=NULL) && strstr(msg->u.crud.source, "parodus") != NULL))
 			{
 				free(message->msg);
 			}

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -348,7 +348,9 @@ void *processUpstreamMessage()
 				}
 			}
 			ParodusPrint("Free for upstream decoded msg\n");
-			wrp_free_struct(msg);
+			if (msg) {
+                wrp_free_struct(msg);
+            }
 			msg = NULL;
 			free(message);
 			message = NULL;

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -78,7 +78,7 @@ pthread_mutex_t *get_global_nano_mut(void)
 
 void packMetaData()
 {
-    static char boot_time[256]={'\0'};
+    char boot_time[256]={'\0'};
     //Pack the metadata initially to reuse for every upstream msg sending to server
     ParodusPrint("-------------- Packing metadata ----------------\n");
     sprintf(boot_time, "%d", get_parodus_cfg()->boot_time);


### PR DESCRIPTION
Need to find out if the test is valid, since the crash happens because msg-unpack returns an error, which is now handled correctly.
Left to do:
1. Is the message packed incorrectly?
2. Why does it fail unpack?
3. Is the test itself valid and therefore should pass?

