### PR TITLE
connection to retry find_servers after failure after redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Default HTTP port to 80 and HTTPS port to 443.
 - Updates to how `nopoll` is called have been implemented.
 - Refactored connection.c and updated corresponding unit tests
+- Connection retry logic tweak for 501s
 
 ### Fixed
 - 64 bit pointer fixes (#144, #145).

--- a/src/connection.c
+++ b/src/connection.c
@@ -503,8 +503,7 @@ int connect_and_wait (create_connection_ctx_t *ctx)
 // a) success, or
 // b) need to requery dns
 int keep_trying_to_connect (create_connection_ctx_t *ctx, 
-	int max_retry_sleep,
-	int query_dns_status)
+	int max_retry_sleep)
 {
     backoff_timer_t backoff_timer;
     int rtn;
@@ -520,8 +519,7 @@ int keep_trying_to_connect (create_connection_ctx_t *ctx,
         continue;
       backoff_delay (&backoff_timer); // 3,7,15,31 ..
       if (rtn == CONN_WAIT_RETRY_DNS)
-        if (query_dns_status < 0)
-          return false;  //find_server again
+        return false;  //find_server again
       // else retry
     }
 }
@@ -562,7 +560,7 @@ int createNopollConnection(noPollCtx *ctx)
 	  if (query_dns_status == FIND_INVALID_DEFAULT)
 		return nopoll_false;
 	  set_current_server (&conn_ctx);
-	  if (keep_trying_to_connect (&conn_ctx, max_retry_sleep, query_dns_status))
+	  if (keep_trying_to_connect (&conn_ctx, max_retry_sleep))
 		break;
 	  // retry dns query
 	}

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -51,8 +51,7 @@ extern int nopoll_connect (create_connection_ctx_t *ctx, int is_ipv6);
 extern int wait_connection_ready (create_connection_ctx_t *ctx);
 extern int connect_and_wait (create_connection_ctx_t *ctx);
 extern int keep_trying_to_connect (create_connection_ctx_t *ctx, 
-	int max_retry_sleep,
-	int query_dns_status);
+	int max_retry_sleep);
 
 
 /*----------------------------------------------------------------------------*/
@@ -802,7 +801,7 @@ void test_keep_trying ()
   expect_function_call (nopoll_conn_is_ok);
   will_return (nopoll_conn_wait_for_status_until_connection_ready, nopoll_true);
   expect_function_call (nopoll_conn_wait_for_status_until_connection_ready);
-  rtn = keep_trying_to_connect (&ctx, 30, -1);
+  rtn = keep_trying_to_connect (&ctx, 30); // -1);
   assert_int_equal (rtn, true);
 
   test_server.allow_insecure = 0;
@@ -823,24 +822,18 @@ void test_keep_trying ()
   expect_function_call (nopoll_conn_tls_new);
   will_return (nopoll_conn_is_ok, nopoll_true);
   expect_function_call (nopoll_conn_is_ok);
-  mock_wait_status = 0;
   will_return (nopoll_conn_wait_for_status_until_connection_ready, nopoll_true);
   expect_function_call (nopoll_conn_wait_for_status_until_connection_ready);
-  rtn = keep_trying_to_connect (&ctx, 30, 0);
+  rtn = keep_trying_to_connect (&ctx, 30); // 0);
   assert_int_equal (rtn, true);
 
+  mock_wait_status = 0;
   will_return (nopoll_conn_tls_new, NULL);
   expect_function_call (nopoll_conn_tls_new);
   will_return (checkHostIp, 0);
   expect_function_call (checkHostIp);
-  will_return (nopoll_conn_tls_new, &connection1);
-  expect_function_call (nopoll_conn_tls_new);
-  will_return (nopoll_conn_is_ok, nopoll_true);
-  expect_function_call (nopoll_conn_is_ok);
-  will_return (nopoll_conn_wait_for_status_until_connection_ready, nopoll_true);
-  expect_function_call (nopoll_conn_wait_for_status_until_connection_ready);
-  rtn = keep_trying_to_connect (&ctx, 30, 0);
-  assert_int_equal (rtn, true);
+  rtn = keep_trying_to_connect (&ctx, 30); // 0);
+  assert_int_equal (rtn, false);
 
   mock_wait_status = 302;
   mock_redirect = "mydns.mycom.net";
@@ -853,7 +846,7 @@ void test_keep_trying ()
   expect_function_call (nopoll_conn_wait_for_status_until_connection_ready);
   will_return (nopoll_conn_ref_count, 0);
   expect_function_call (nopoll_conn_ref_count);
-  rtn = keep_trying_to_connect (&ctx, 30, -1);
+  rtn = keep_trying_to_connect (&ctx, 30); // -1);
   assert_int_equal (rtn, false);
 }
 


### PR DESCRIPTION
Change connection retry logic to find_servers after a failure after a redirect.