### PR TITLE
Added Security Feature: Mutual Authentication (mTLS or two way TLS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,10 @@ include_directories(${INCLUDE_DIR}
 
 endif (FEATURE_DNS_QUERY)
 
+if(ENABLE_MUTUAL_AUTH)
+       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_MUTUAL_AUTH ")
+endif(ENABLE_MUTUAL_AUTH)
+
 if (BUILD_TESTING)
 # cmocka external dependency
 #-------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ make test
 
 - /jwt-public-key-file -JWT token validation key
 
+# if ENABLE_MUTUAL_AUTH is enabled
+
+- /client-cert-path - Provide the client cert for establishing a mutual auth secure connection
+
+- /client-key-path - Provide the client cert key for establishing a mutual auth secure connection
+
 ```
 
 # Sample parodus start commands:

--- a/src/config.c
+++ b/src/config.c
@@ -390,6 +390,10 @@ int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
         {"boot-time-retry-wait",    required_argument, 0, 'w'},
 	{"token-acquisition-script",     required_argument, 0, 'J'},
 	{"crud-config-file",        required_argument, 0, 'C'},
+#ifdef ENABLE_MUTUAL_AUTH
+	{"client-cert-path",		required_argument, 0, 'q'},
+	{"client-key-path",		required_argument, 0, 'K'},
+#endif
         {0, 0, 0, 0}
     };
     int c;
@@ -413,9 +417,14 @@ int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 
       /* getopt_long stores the option index here. */
       int option_index = 0;
+#ifdef ENABLE_MUTUAL_AUTH
+      c = getopt_long (argc, argv, "m:s:f:d:r:n:b:u:t:o:i:l:p:e:D:j:a:k:c:T:w:J:46:Cq:K:",
+				long_options, &option_index);
+#else
       c = getopt_long (argc, argv, "m:s:f:d:r:n:b:u:t:o:i:l:p:e:D:j:a:k:c:T:w:J:46:C",
 				long_options, &option_index);
 
+#endif
       /* Detect the end of the options. */
       if (c == -1)
         break;
@@ -563,6 +572,16 @@ int parseCommandLine(int argc,char **argv,ParodusCfg * cfg)
 		  cfg->crud_config_file = strdup(optarg);
 		  ParodusInfo("crud_config_file is %s\n", cfg->crud_config_file);
 		  break;
+
+#ifdef ENABLE_MUTUAL_AUTH
+        case 'q':
+          parStrncpy(cfg->client_cert_path, optarg,sizeof(cfg->client_cert_path));
+          break;
+
+        case 'K':
+          parStrncpy(cfg->client_key_path, optarg,sizeof(cfg->client_key_path));
+          break;
+#endif
 
         case '?':
           /* getopt_long already printed an error message. */

--- a/src/config.h
+++ b/src/config.h
@@ -99,6 +99,10 @@ typedef struct
     char webpa_auth_token[4096];
     char token_acquisition_script[64];
     char token_read_script[64];
+#ifdef ENABLE_MUTUAL_AUTH
+    char client_cert_path[64];
+    char client_key_path[64];
+#endif
 	char *crud_config_file;
 	char *cloud_status;
 	char *cloud_disconnect;

--- a/src/connection.c
+++ b/src/connection.c
@@ -618,13 +618,22 @@ static char* build_extra_headers( const char *auth, const char *device_id,
 static noPollConnOpts * createConnOpts (char * extra_headers, bool secure)
 {
     noPollConnOpts * opts;
+    char * client_cert_path = NULL;
+    char * client_key_path = NULL;
     
     opts = nopoll_conn_opts_new ();
     if(secure) 
 	{
 	    if(strlen(get_parodus_cfg()->cert_path) > 0)
             {
-                nopoll_conn_opts_set_ssl_certs(opts, NULL, NULL, NULL, get_parodus_cfg()->cert_path);
+#ifdef ENABLE_MUTUAL_AUTH
+               if (strlen(get_parodus_cfg()->client_cert_path) > 0)
+                       client_cert_path = get_parodus_cfg()->client_cert_path;
+
+               if (strlen(get_parodus_cfg()->client_key_path) > 0)
+                       client_key_path = get_parodus_cfg()->client_key_path;
+#endif
+                nopoll_conn_opts_set_ssl_certs(opts, client_cert_path, client_key_path, NULL, get_parodus_cfg()->cert_path);
             }
 	    nopoll_conn_opts_ssl_peer_verify (opts, nopoll_true);
 	    nopoll_conn_opts_set_ssl_protocol (opts, NOPOLL_METHOD_TLSV1_2);


### PR DESCRIPTION
This change adds support for two new program parameters
-q "client_cert_path" and -k "client key path"
Where here client is the CPE, so It will be the CPE cert and
corresponding key.

Having those two parameters we are in position to pass them
on the nopoll_conn_opts_set_ssl_certs function. This function,
previously, was being set with NULL values.

As most parameters have a path with 64 characters, we also created
those (cert and key) paths with that length.

We also changed the README.md accordingly, to show how to enable
and use this feature.

Signed-off-by: Nuno Martins <nuno.mmartins@parceiros.nos.pt>