### PR TITLE
add unit test for 503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updates to how `nopoll` is called have been implemented.
 - Refactored connection.c and updated corresponding unit tests
 - Switched from nanomsg (Release 1.1.2) to NNG (Release v1.0.1)
+- Changed connection logic (connection.c) for retries, and added unit test
 
 ### Fixed
 - 64 bit pointer fixes (#144, #145).

--- a/src/connection.c
+++ b/src/connection.c
@@ -503,8 +503,7 @@ int connect_and_wait (create_connection_ctx_t *ctx)
 // a) success, or
 // b) need to requery dns
 int keep_trying_to_connect (create_connection_ctx_t *ctx, 
-	int max_retry_sleep,
-	int query_dns_status)
+	int max_retry_sleep)
 {
     backoff_timer_t backoff_timer;
     int rtn;
@@ -520,8 +519,7 @@ int keep_trying_to_connect (create_connection_ctx_t *ctx,
         continue;
       backoff_delay (&backoff_timer); // 3,7,15,31 ..
       if (rtn == CONN_WAIT_RETRY_DNS)
-        if (query_dns_status < 0)
-          return false;  //find_server again
+        return false;  //find_server again
       // else retry
     }
 }
@@ -562,7 +560,7 @@ int createNopollConnection(noPollCtx *ctx)
 	  if (query_dns_status == FIND_INVALID_DEFAULT)
 		return nopoll_false;
 	  set_current_server (&conn_ctx);
-	  if (keep_trying_to_connect (&conn_ctx, max_retry_sleep, query_dns_status))
+	  if (keep_trying_to_connect (&conn_ctx, max_retry_sleep))
 		break;
 	  // retry dns query
 	}


### PR DESCRIPTION
Change connection logic so that after an error that is not 403 or 3xx (redirect), we retry find_servers.
Also add unit test for this (code 503).