### PR TITLE
revert temporary CMake reference to bill1600/seshat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed connection logic (connection.c) for retries, and added unit test
 - Partner-id comparison made case insensitive
 - Reverted from NNG to nanomag (v1.1.2)
+- reverted temporary CMake reference to https://github.com/bill1600/seshat
 
 ## [1.0.1] - 2018-07-18
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/_install)
 set(PREFIX_DIR ${CMAKE_CURRENT_BINARY_DIR}/_prefix)
 set(INCLUDE_DIR ${INSTALL_DIR}/include)
 set(INCLUDE_UCRESOLV ${PREFIX_DIR}/ucresolv/src/ucresolv/include)
+set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
 set(LIBRARY_DIR ${INSTALL_DIR}/lib)
 set(LIBRARY_DIR64 ${INSTALL_DIR}/lib64)
 set(COMMON_LIBRARY_DIR ${INSTALL_DIR}/lib/${CMAKE_LIBRARY_ARCHITECTURE})
@@ -170,9 +171,8 @@ if (ENABLE_SESHAT)
 ExternalProject_Add(libseshat
     DEPENDS cJSON trower-base64 msgpack nanomsg wrp-c
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/libseshat
-    GIT_REPOSITORY https://github.com/bill1600/seshat.git
-    #GIT_TAG "261a9b330a4ab1393556b17ccf55db93effdf982"
-    GIT_TAG "revert_from_NNG"
+    GIT_REPOSITORY https://github.com/Comcast/seshat.git
+    GIT_TAG "700865fd0d96a50cd91309f0c4efcd3c0887cd88"
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_TESTING=OFF
     	          -DMAIN_PROJ_BUILD=ON
     	          -DMAIN_PROJ_LIB_PATH=${LIBRARY_DIR}


### PR DESCRIPTION
Update CMakeLists.txt to revert temporary reference to https://github.com/bill1600/seshat