### PR TITLE
patches ucresolv to use option RES_USEVC and not call send_dg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - used mutex protection to make client list and nn_sends thread safe
 - put mutex lock into get_global_node
 - change svc alive from a thread to a function called every 30 sec from main
+- patched usresolv so it uses option RES_USEVC and does not call send_dg
 
 ## [1.0.1] - 2018-07-18
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/_install)
 set(PREFIX_DIR ${CMAKE_CURRENT_BINARY_DIR}/_prefix)
 set(INCLUDE_DIR ${INSTALL_DIR}/include)
 set(INCLUDE_UCRESOLV ${PREFIX_DIR}/ucresolv/src/ucresolv/include)
+set(RESOLV_SRC ${PREFIX_DIR}/ucresolv/src/ucresolv/src)
 set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
 set(LIBRARY_DIR ${INSTALL_DIR}/lib)
 set(LIBRARY_DIR64 ${INSTALL_DIR}/lib64)
@@ -204,6 +205,7 @@ ExternalProject_Add(ucresolv
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/ucresolv
     GIT_REPOSITORY https://github.com/Comcast/libucresolv.git
     GIT_TAG "1.0.0"
+    PATCH_COMMAND patch ${RESOLV_SRC}/res_init.c < ${PATCHES_DIR}/resolv.patch
     CMAKE_ARGS += -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 )
 add_library(libucresolv STATIC SHARED IMPORTED)

--- a/patches/resolv.patch
+++ b/patches/resolv.patch
@@ -1,0 +1,2 @@
+409a410
+> 	statp->options |= RES_USEVC;


### PR DESCRIPTION
patch ucresolv so that we don't so datagrams while resolving.