### PR TITLE
fix mutex error in service alive

### DIFF
--- a/src/service_alive.c
+++ b/src/service_alive.c
@@ -114,8 +114,9 @@ void *serviceAliveTask()
 				        byte = 0;
 				        if(ret == 0)
 				        {
-					        ParodusPrint("Deletion from list is success, doing resync with head\n");
+						release_global_node ();
 					        temp= get_global_node();
+					        ParodusInfo("Deletion from list is success, doing resync with head\n");
 					        ret = -1;
 				        }
 				        else


### PR DESCRIPTION
Fix mutex error in service alive task that causes it to get stuck after a client is removed.

This can be tested locally as follows, if you have an app, like the libparodus test app, that talks to parodus.
1. start parodus
2. start the test app and register a client.
3. Now kill the client, by exiting the test app.
4. If working correctly, you should see the message
No clients are registered, waiting...
after 30 sec or so.

If you run an earlier version of parodus, you don't see this message after a client is removed.
Parodus is still alive, but the service alive task is stuck.
