### PR TITLE
Fix nanomsg client close handling

### DIFF
--- a/src/client_list.c
+++ b/src/client_list.c
@@ -220,6 +220,16 @@ int deleteFromList(char* service_name)
 			}
 			
 			ParodusPrint("Deleting the node\n");
+                        if(nn_shutdown(curr_node->sock, curr_node->endpoint) < 0)
+                        {
+                           ParodusError ("nn_shutdown socket=%d endpt=%d, err=%d\n", 
+				curr_node->sock, curr_node->endpoint, errno);
+                        }
+			if (nn_close (curr_node->sock) < 0)
+                        {
+                           ParodusError ("nn_close socket=%d err=%d\n", 
+				curr_node->sock, errno);
+                        }
 			free( curr_node );
 			curr_node = NULL;
 			ParodusInfo("Deleted successfully and returning..\n");

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -76,7 +76,11 @@ int addToList( wrp_msg_t **msg)
             if(rc < 0)
             {
                 ParodusError ("Unable to connect socket (errno=%d, %s)\n",errno, strerror(errno));
-                nn_close (sock);
+		if (nn_close (sock) < 0)
+                {
+                   ParodusError ("nn_close socket=%d (err=%d, %s)\n", 
+			sock, errno, strerror(errno));
+		}
                 
             }
             else

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -87,6 +87,7 @@ int addToList( wrp_msg_t **msg)
 		{
     			memset( new_node, 0, sizeof( reg_list_item_t ) );
     			new_node->sock = sock;
+                        new_node->endpoint = rc;
     			ParodusPrint("new_node->sock is %d\n", new_node->sock);
     			
     			

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -30,6 +30,7 @@
 typedef struct reg_list_item
 {
 	int sock;
+	int endpoint;
 	char service_name[32];
 	char url[100];
 	struct reg_list_item *next;

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -418,6 +418,7 @@ void *processUpstreamMessage()
 									ParodusError("Failed to get device_id\n");
 								}
 						} else if (WRP_MSG_TYPE__SVC_ALIVE != msgType) {
+						  /* Don't reply to service alive message */
 							sendUpstreamMsgToServer(&message->msg, message->len);
 						}
 					}

--- a/src/upstream.c
+++ b/src/upstream.c
@@ -190,6 +190,16 @@ void *handle_upstream()
                     ParodusError("failure in allocation for message\n");
                 }
             }
+	    if(nn_shutdown(sock, bind) < 0)
+	    {
+	        ParodusError ("nn_shutdown bind socket=%d endpt=%d, err=%d\n", 
+		    sock, bind, errno);
+	    }
+	    if (nn_close (sock) < 0)
+	    {
+	        ParodusError ("nn_close bind socket=%d err=%d\n", 
+		    sock, errno);
+	    }
         }
     }
     else
@@ -234,7 +244,7 @@ void *processUpstreamMessage()
             if(rv > 0)
             {
                 msgType = msg->msg_type;				   
-                if(msgType == 9)
+                if(msgType == WRP_MSG_TYPE__SVC_REGISTRATION)
                 {
                     ParodusInfo("\n Nanomsg client Registration for Upstream\n");
                     //Extract serviceName and url & store it in a linked list for reg_clients
@@ -249,12 +259,16 @@ void *processUpstreamMessage()
                             {
                                 ParodusInfo("match found, client is already registered\n");
                                 parStrncpy(temp->url,msg->u.reg.url, sizeof(temp->url));
-                                if(nn_shutdown(temp->sock, 0) < 0)
+                                if(nn_shutdown(temp->sock, temp->endpoint) < 0)
                                 {
-                                    ParodusError ("nn_shutdown socket=%d err=%d\n", 
+                                    ParodusError ("nn_shutdown socket=%d endpt=%d, err=%d\n", 
+					temp->sock, temp->endpoint, errno);
+                                }
+				if (nn_close (temp->sock) < 0)
+                                {
+                                    ParodusError ("nn_close socket=%d err=%d\n", 
 					temp->sock, errno);
                                 }
-				nn_close (temp->sock);
 
                                 temp->sock = nn_socket(AF_SP,NN_PUSH );
                                 if(temp->sock >= 0)
@@ -272,6 +286,7 @@ void *processUpstreamMessage()
                                     }
                                     else
                                     {
+                                        temp->endpoint = rc;
                                         ParodusInfo("Client registered before. Sending ack on socket %d\n", temp->sock); 
                                         status =sendAuthStatus(temp);
 
@@ -402,9 +417,7 @@ void *processUpstreamMessage()
 								{
 									ParodusError("Failed to get device_id\n");
 								}
-						}
-						else
-						{
+						} else if (WRP_MSG_TYPE__SVC_ALIVE != msgType) {
 							sendUpstreamMsgToServer(&message->msg, message->len);
 						}
 					}

--- a/tests/test_upstream.c
+++ b/tests/test_upstream.c
@@ -273,6 +273,10 @@ void test_handleUpstreamNull()
     expect_function_call(nn_bind);
     will_return(nn_recv, 12);
     expect_function_call(nn_recv);
+    will_return(nn_shutdown, 0);
+    expect_function_call(nn_shutdown);
+    will_return(nn_close, 0);
+    expect_function_call(nn_close);
     handle_upstream();
 }
 
@@ -294,6 +298,10 @@ void test_handle_upstream()
     expect_function_call(nn_bind);
     will_return(nn_recv, 12);
     expect_function_call(nn_recv);
+    will_return(nn_shutdown, 0);
+    expect_function_call(nn_shutdown);
+    will_return(nn_close, 0);
+    expect_function_call(nn_close);
     handle_upstream();
     free(UpStreamMsgQ->next);
     free(UpStreamMsgQ);


### PR DESCRIPTION
save endpoint and use in nn_shutdown call.
log error message on nn_close.
Save nanomsg client endpoint and use in shutdown call. 
Fix socket leak during client disconnect 